### PR TITLE
Register imas-muscle3 actors as importable ymmsl modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,27 @@ pytest
 # How to use
 To add an actor to your MUSCLE3 workflow, add the following to the implementations in your ymmsl file:
 
-```bash
+```yaml
 implementations:
   *component_name*:
     executable: python
     args: -u -m imas_muscle3.actors.*component_name*
 ```
 Check the actor specific documentation pages to find the relevant ports, settings, etc.
+
+When using MUSCLE3 0.9.1 or newer with yMMSL v0.2, you can import the implementations
+directly:
+
+```yaml
+ymmsl_version: v0.2
+imports:
+- from imas_muscle3 import implementation source_component
+models:
+  mymodel:
+    components:
+      mysource:
+        ports:
+          o_f: core_profiles_out
+        description: Core profiles source
+        implementation: source_component
+```

--- a/imas_muscle3/actors/__init__.py
+++ b/imas_muscle3/actors/__init__.py
@@ -1,0 +1,27 @@
+import sys
+
+
+ACTORS = f"""
+ymmsl_version: v0.2
+description: yMMSL configuration for actors exposed by IMAS-MUSCLE3.
+programs:
+  source_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.source_component
+  sink_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.sink_component
+  sink_source_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.sink_source_component
+  olc_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.olc_component
+  accumulator_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.accumulator_component
+  visualization_component:
+    executable: {sys.executable}
+    args: -u -m imas_muscle3.actors.visualization_component
+"""
+"""yMMSL configuration for all actors exposed by IMAS-MUSCLE3."""

--- a/imas_muscle3/utils.py
+++ b/imas_muscle3/utils.py
@@ -3,7 +3,12 @@ from typing import List, Optional, TypeVar, cast, overload
 from urllib.parse import urlparse, urlunparse
 
 from libmuscle import Instance
-from ymmsl import Operator, SettingValue
+from ymmsl import Operator
+
+try:
+    from ymmsl import SettingValue
+except ImportError:
+    from ymmsl.v0_2 import SettingValue
 
 TSetting = TypeVar("TSetting", bound=SettingValue)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ linting = [
 [project.urls]
 homepage = "https://github.com/iterorganization/IMAS-MUSCLE3"
 
+[project.entry-points."ymmsl.module"]
+imas_muscle3 = "imas_muscle3.actors:ACTORS"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["imas_muscle3*"]

--- a/tests/test_import_implementations.py
+++ b/tests/test_import_implementations.py
@@ -1,0 +1,46 @@
+from importlib.metadata import version
+
+import ymmsl
+import pytest
+
+ymmsl_version_tuple = tuple(map(int, version("ymmsl").split(".")[:2]))
+skip_import_tests = pytest.mark.skipif(
+    ymmsl_version_tuple < (0, 16), reason="Entry points not implemented in yMMSL"
+)
+
+components = [
+    "source_component",
+    "sink_component",
+    "sink_source_component",
+    "olc_component",
+    "accumulator_component",
+    "visualization_component",
+]
+
+
+@skip_import_tests
+@pytest.mark.parametrize("component_name", components)
+def test_import_component(component_name: str) -> None:
+    # local import to avoid ImportError for older ymmsl versions
+    from ymmsl.v0_2 import Configuration, resolve, Reference
+
+    config = ymmsl.load_as(
+        Configuration,
+        f"""
+ymmsl_version: v0.2
+imports:
+- from imas_muscle3 import implementation {component_name}
+models:
+  test:
+    components:
+      test_component:
+        ports: {{}}
+        description: Test component
+        implementation: {component_name}
+resources:
+  test_component:
+    threads: 1
+""",
+    )
+    resolve(Reference([]), config)
+    config.check_consistent()


### PR DESCRIPTION
Allows users to use the new "import" functionality (see https://muscle3.readthedocs.io/en/latest/nested_models.html#importing-implementations) when IMAS-MUSCLE3 is installed. See the README.md for an example:

TODO:
- [ ] Update documentation with additional examples
- [ ] Ensure that imas-muscle3 can work with the latest ymmsl/muscle3 release